### PR TITLE
strip root from dst if its there

### DIFF
--- a/src/static_compiler/management/commands/compilestatic.py
+++ b/src/static_compiler/management/commands/compilestatic.py
@@ -109,7 +109,10 @@ def apply_preprocessors(root, src, dst, processors):
     file individually.
     """
     matches = [(pattern, cmds) for pattern, cmds in processors.iteritems() if fnmatch(src, pattern)]
-    if src == dst and not matches:
+    dst_noroot = dst
+    if dst.startswith(os.path.join(root, '')):
+        dst_noroot = dst[len(os.path.join(root, '')):]
+    if src == dst_noroot and not matches:
         return False
 
     params = get_format_params(dst)


### PR DESCRIPTION
Precompilering/Preprocessing was copying files it shouldn't (in my setup) because `src != dst` because `dst` has the `root` in it already.
