### PR TITLE
finder needs to list static bundles in order to find it during collectstatic

### DIFF
--- a/src/static_compiler/finders.py
+++ b/src/static_compiler/finders.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+from django.conf import settings
 from django.contrib.staticfiles import finders
+from django.core.files.storage import FileSystemStorage
 from static_compiler.storage import StaticCompilerFileStorage
 
 
@@ -12,4 +14,6 @@ class StaticCompilerFinder(finders.BaseStorageFinder):
     storage = StaticCompilerFileStorage
 
     def list(self, ignore_patterns):
-        return []
+        filesystem_storage = FileSystemStorage(location=settings.STATIC_ROOT)
+        for pkg in settings.STATIC_BUNDLES['packages'].keys():
+            yield pkg, filesystem_storage

--- a/src/static_compiler/management/commands/compilestatic.py
+++ b/src/static_compiler/management/commands/compilestatic.py
@@ -12,6 +12,7 @@ from django.core.management.base import BaseCommand
 from django.utils.datastructures import SortedDict
 
 from static_compiler.constants import DEFAULT_CACHE_DIR
+from static_compiler.finders import StaticCompilerFinder
 
 
 def ensure_dirs(dst):
@@ -28,6 +29,9 @@ def copy_file(src, dst):
 def find_static_files(ignore_patterns=()):
     found_files = SortedDict()
     for finder in finders.get_finders():
+        if isinstance(finder, StaticCompilerFinder):
+            continue
+
         for path, storage in finder.list(ignore_patterns):
             found_files[path] = storage.path(path)
     return found_files


### PR DESCRIPTION
Specifically, if used with CachedStaticFilesStorage, it will hash static files 
for proper cache busting.  Otherwise, collectstatic has no idea about the 
created bundles.
