### PR TITLE
Better error messaging when source file could not be found.

### DIFF
--- a/src/static_compiler/templatetags/static_compiler.py
+++ b/src/static_compiler/templatetags/static_compiler.py
@@ -63,11 +63,15 @@ def staticbundle(bundle, mimetype=None, **attrs):
 
             abs_src = get_file_path(src)
 
-            current_mtime = os.stat(abs_src).st_mtime
+            if abs_src is not None:
+                current_mtime = os.stat(abs_src).st_mtime
 
-            if current_mtime != cached_mtime:
-                changed.add(src)
-                BUNDLE_CACHE[src] = current_mtime
+                if current_mtime != cached_mtime:
+                    changed.add(src)
+                    BUNDLE_CACHE[src] = current_mtime
+            elif settings.TEMPLATE_DEBUG:
+                raise template.TemplateSyntaxError("The source file '%s' could "
+                    "not be located." % src)
 
         if changed:
             logger.info('Regenerating %s due to changes: %s', bundle, ' '.join(changed))


### PR DESCRIPTION
This raises a template error when in TEMPLATE_DEBUG mode to notify the developer that the source file could not be found. Otherwise os.stat gets called with None and that error is unclear what actually happened. When not in TEMPLATE_DEBUG the file is excluded.
