### PR TITLE
DEBUG==True doesn't imply that STATIC_BUNDLES is defined

### DIFF
--- a/src/static_compiler/templatetags/static_compiler.py
+++ b/src/static_compiler/templatetags/static_compiler.py
@@ -38,7 +38,7 @@ def staticbundle(bundle, mimetype=None, **attrs):
     """
     config = getattr(settings, 'STATIC_BUNDLES', {})
 
-    if settings.DEBUG and bundle in config['packages']:
+    if settings.DEBUG and 'packages' in config and bundle in config['packages']:
         cache_root = os.path.join(settings.STATIC_ROOT, config.get('cache') or DEFAULT_CACHE_DIR)
 
         changed = set()


### PR DESCRIPTION
Trying to run Sentry in debug mode without setting up all the node requirements throws an error. The template tag shouldn't assume that a dev environment will have the node bits installed.
